### PR TITLE
Make filter expression builder op public

### DIFF
--- a/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionBuilder.java
+++ b/spring-ai-core/src/main/java/org/springframework/ai/vectorstore/filter/FilterExpressionBuilder.java
@@ -56,7 +56,7 @@ import org.springframework.ai.vectorstore.filter.Filter.Value;
  */
 public class FilterExpressionBuilder {
 
-	record Op(Filter.Operand expression) {
+	public record Op(Filter.Operand expression) {
 
 		public Filter.Expression build() {
 			if (expression instanceof Filter.Group group) {

--- a/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
+++ b/spring-ai-docs/src/main/antora/modules/ROOT/pages/api/vectordbs.adoc
@@ -147,7 +147,7 @@ Consider the following examples:
 
 === Filter.Expression
 
-You can create an instance of `Filter.Expression` with a `FilterExpressionbuilder` that exposes a fluent API.
+You can create an instance of `Filter.Expression` with a `FilterExpressionBuilder` that exposes a fluent API.
 A simple example is as follows:
 
 [source, java]


### PR DESCRIPTION
Following the simple example for filter expressions, when I do the following:
```
val b = FilterExpressionBuilder()
val expression: Expression = b.eq("state", "Oregon").build()
```
I get these errors:
```
Type FilterExpressionBuilder.Op! is inaccessible in this context due to: public/*package*/ final class Op
Cannot access 'Op': it is package-private in 'FilterExpressionBuilder'
```
I think the fix is simply making it public. 